### PR TITLE
ci(TU-25699): updated sonar action to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ jobs:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v2
+        uses: SonarSource/sonarqube-scan-action@v5
+        with:
+          args: >
+            -Dsonar.projectVersion=${{ github.run_id }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_CLOUD_TOKEN }}
+          LC_ALL: "C.UTF-8"


### PR DESCRIPTION
Jira Ticket: [TU-25699](https://typeform.atlassian.net/browse/TU-25699)

---

## Description

`SonarSource/sonarcloud-github-action@master` is now deprecated. We should update all our repos to use the `sonarqube-scan-action` action instead.

[TU-25699]: https://typeform.atlassian.net/browse/TU-25699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ